### PR TITLE
Simplify evaluation workflow to image upload only

### DIFF
--- a/app/api/evaluations/route.ts
+++ b/app/api/evaluations/route.ts
@@ -22,6 +22,57 @@ export async function GET() {
   }
 }
 
+function mapErrorToResponse(error: unknown) {
+  if (error instanceof Error) {
+    if (error.message.includes('Zero_Defect_Gemini')) {
+      return {
+        status: 503,
+        message:
+          'Интеграция Gemini не настроена. Убедитесь, что переменная окружения Zero_Defect_Gemini задана.',
+      };
+    }
+
+    if (error.message.includes('Gemini API вернул ошибку')) {
+      return {
+        status: 502,
+        message: 'Gemini вернул ошибку. Проверьте ключ и доступность сервиса.',
+      };
+    }
+
+    if (error.message.includes('VERCEL_BLOB')) {
+      return {
+        status: 503,
+        message:
+          'Хранилище Vercel Blob недоступно. Проверьте VERCEL_BLOB_TOKEN и настройки доступа.',
+      };
+    }
+
+    if (error.message.includes('Не удалось сохранить файл оценки')) {
+      return {
+        status: 503,
+        message: 'Не удалось сохранить результат оценки. Проверьте настройки хранилища.',
+      };
+    }
+
+    if (error.message.includes('Не удалось загрузить изображение макета')) {
+      return {
+        status: 400,
+        message: error.message,
+      };
+    }
+
+    return {
+      status: 500,
+      message: error.message || 'Ошибка при обработке оценки',
+    };
+  }
+
+  return {
+    status: 500,
+    message: 'Ошибка при обработке оценки',
+  };
+}
+
 export async function POST(request: Request) {
   let payload: EvaluationRequest;
   try {
@@ -50,6 +101,7 @@ export async function POST(request: Request) {
     return NextResponse.json(evaluation, { status: 201 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: 'Ошибка при обработке оценки' }, { status: 500 });
+    const { status, message } = mapErrorToResponse(error);
+    return NextResponse.json({ message }, { status });
   }
 }

--- a/app/api/evaluations/route.ts
+++ b/app/api/evaluations/route.ts
@@ -1,25 +1,15 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { buildSummary, runEvaluation, validateInputs } from '../../../lib/evaluation';
+import { buildSummary, runEvaluation } from '../../../lib/evaluation';
 import { saveEvaluation, listEvaluations } from '../../../lib/storage';
 import type { EvaluationRequest, EvaluationResult } from '../../../lib/types';
 
-const optionalText = z.preprocess(
-  (value) => (typeof value === 'string' ? value : ''),
-  z.string(),
-);
-
-const optionalUrl = z.preprocess(
-  (value) => (typeof value === 'string' ? value.trim() : ''),
-  z.union([z.literal(''), z.string().url()]),
-);
-
 const requestSchema = z.object({
-  projectTitle: optionalText,
-  projectBrief: optionalText,
-  structureJson: optionalText,
-  designSystemUrl: optionalUrl,
-  layoutImageUrl: optionalUrl,
+  projectTitle: z.preprocess((value) => (typeof value === 'string' ? value : ''), z.string()),
+  layoutImageUrl: z.preprocess(
+    (value) => (typeof value === 'string' ? value.trim() : ''),
+    z.string().url(),
+  ),
 });
 
 export async function GET() {
@@ -33,17 +23,13 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const url = new URL(request.url);
-  const confirmGoal = url.searchParams.has('confirmGoal');
-
   let payload: EvaluationRequest;
   try {
     const json = await request.json();
     payload = requestSchema.parse(json);
     payload = {
-      ...payload,
       projectTitle: payload.projectTitle.trim(),
-      projectBrief: payload.projectBrief.trim(),
+      layoutImageUrl: payload.layoutImageUrl,
     };
   } catch (error) {
     console.error(error);
@@ -51,22 +37,6 @@ export async function POST(request: Request) {
   }
 
   try {
-    const validation = await validateInputs(payload);
-
-    if (!validation.jsonMatchesImage) {
-      return NextResponse.json({ message: 'JSON не соответствует изображению' }, { status: 409 });
-    }
-
-    if (!confirmGoal && validation.needsBusinessGoalConfirmation) {
-      return NextResponse.json(
-        {
-          message: 'Требуется подтвердить бизнес-задачу',
-          businessGoal: validation.businessGoal,
-        },
-        { status: 428 },
-      );
-    }
-
     const steps = await runEvaluation(payload);
     const summary = buildSummary(steps, payload);
     const evaluation: EvaluationResult = {

--- a/components/EvaluationForm.tsx
+++ b/components/EvaluationForm.tsx
@@ -7,245 +7,92 @@ interface ToastState {
   tone: 'default' | 'danger' | 'success';
 }
 
+function normalizeTitle(fileName: string) {
+  const withoutExtension = fileName.replace(/\.[^/.]+$/, '').trim();
+  return withoutExtension || 'Оценка макета';
+}
+
 export function EvaluationForm() {
-  const [designSystemUrl, setDesignSystemUrl] = useState<string>('');
-  const [layoutImageUrl, setLayoutImageUrl] = useState<string>('');
-  const [structureJson, setStructureJson] = useState('');
-  const [projectTitle, setProjectTitle] = useState('');
-  const [projectBrief, setProjectBrief] = useState('');
-  const [businessGoalSuggestion, setBusinessGoalSuggestion] = useState<string | null>(null);
-  const [needsGoalConfirmation, setNeedsGoalConfirmation] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
 
-  const handleUpload = async (event: FormEvent<HTMLFormElement>, type: 'design-system' | 'layout') => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setToast(null);
+
     const formData = new FormData(event.currentTarget);
     const file = formData.get('file');
-    if (!(file instanceof File)) {
+
+    if (!(file instanceof File) || file.size === 0) {
+      setToast({ message: 'Выберите изображение макета перед отправкой.', tone: 'danger' });
       return;
     }
 
-    try {
-      const endpoint = type === 'design-system' ? '/api/upload/design-system' : '/api/upload/layout';
-      const response = await fetch(`${endpoint}?filename=${encodeURIComponent(file.name)}`, {
-        method: 'POST',
-        body: file,
-      });
-
-      if (!response.ok) {
-        throw new Error('Не удалось загрузить файл');
-      }
-
-      const result = await response.json();
-      if (type === 'design-system') {
-        setDesignSystemUrl(result.url);
-      } else {
-        setLayoutImageUrl(result.url);
-      }
-      setToast({ message: 'Файл загружен', tone: 'success' });
-      event.currentTarget.reset();
-    } catch (error) {
-      console.error(error);
-      setToast({ message: 'Ошибка загрузки файла', tone: 'danger' });
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
     setIsSubmitting(true);
-    setToast(null);
 
     try {
+      const uploadResponse = await fetch(
+        `/api/upload/layout?filename=${encodeURIComponent(file.name || 'layout.png')}`,
+        {
+          method: 'POST',
+          body: file,
+        },
+      );
+
+      if (!uploadResponse.ok) {
+        throw new Error('Не удалось загрузить изображение макета.');
+      }
+
+      const uploadResult = (await uploadResponse.json()) as { url: string };
+      const projectTitle = normalizeTitle(file.name || 'layout');
+
       const response = await fetch('/api/evaluations', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          layoutImageUrl: uploadResult.url,
           projectTitle,
-          projectBrief,
-          structureJson,
-          designSystemUrl,
-          layoutImageUrl,
-        }),
-      });
-
-      if (response.status === 409) {
-        setToast({ message: 'JSON и макет не совпадают. Попробуйте снова.', tone: 'danger' });
-        return;
-      }
-
-      if (response.status === 428) {
-        const payload = await response.json();
-        setBusinessGoalSuggestion(payload.businessGoal);
-        setNeedsGoalConfirmation(true);
-        if (payload.businessGoal) {
-          setProjectBrief(payload.businessGoal);
-        }
-        setToast({ message: 'Мы уточнили бизнес-задачу. Подтвердите или исправьте.', tone: 'default' });
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error('Ошибка при отправке на оценку');
-      }
-
-      setToast({ message: 'Оценка запущена. Обновите список через минуту.', tone: 'success' });
-      setBusinessGoalSuggestion(null);
-      setNeedsGoalConfirmation(false);
-      setProjectTitle('');
-      setProjectBrief('');
-      setStructureJson('');
-      setDesignSystemUrl('');
-      setLayoutImageUrl('');
-    } catch (error) {
-      console.error(error);
-      setToast({ message: 'Не удалось запустить оценку', tone: 'danger' });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleConfirmGoal = async (useSuggestion: boolean) => {
-    if (!businessGoalSuggestion && useSuggestion) return;
-    setIsSubmitting(true);
-    try {
-      const briefToUse = useSuggestion && businessGoalSuggestion ? businessGoalSuggestion : projectBrief;
-      const response = await fetch('/api/evaluations?confirmGoal=1', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          projectTitle,
-          projectBrief: briefToUse,
-          structureJson,
-          designSystemUrl,
-          layoutImageUrl,
         }),
       });
 
       if (!response.ok) {
-        throw new Error('Ошибка при подтверждении цели');
+        throw new Error('Ошибка при отправке макета на оценку.');
       }
 
-      setToast({ message: 'Оценка запущена. Обновите список через минуту.', tone: 'success' });
-      setBusinessGoalSuggestion(null);
-      setNeedsGoalConfirmation(false);
-      setProjectTitle('');
-      setProjectBrief('');
-      setStructureJson('');
-      setDesignSystemUrl('');
-      setLayoutImageUrl('');
+      setToast({ message: 'Оценка запущена. Проверьте историю через минуту.', tone: 'success' });
+      event.currentTarget.reset();
     } catch (error) {
       console.error(error);
-      setToast({ message: 'Не удалось запустить оценку', tone: 'danger' });
+      setToast({
+        message:
+          error instanceof Error ? error.message : 'Не удалось отправить макет на оценку. Попробуйте снова.',
+        tone: 'danger',
+      });
     } finally {
       setIsSubmitting(false);
     }
   };
 
   return (
-    <div className="grid" style={{ gap: '32px' }}>
-      <div className="grid two">
-        <form className="card" onSubmit={(event) => handleUpload(event, 'design-system')}
-          style={{ display: 'grid', gap: '16px', border: '1px dashed rgba(59, 130, 246, 0.4)' }}>
-          <div>
-            <h3 style={{ margin: '0 0 4px' }}>Дизайн-система</h3>
-            <p style={{ margin: 0, color: 'rgba(15,23,42,0.6)', fontSize: '0.9rem' }}>
-              Загрузите файл .md, .txt, .pdf или .doc, если он есть. Это поле опционально.
-            </p>
-          </div>
-          <input name="file" type="file" accept=".md,.txt,.pdf,.doc,.docx" />
-          <button className="button secondary" type="submit">
-            {designSystemUrl ? 'Заменить дизайн-систему' : 'Загрузить дизайн-систему'}
-          </button>
-          {designSystemUrl && (
-            <a href={designSystemUrl} target="_blank" rel="noreferrer" className="badge">
-              Открыть текущий файл
-            </a>
-          )}
-        </form>
-        <form className="card" onSubmit={(event) => handleUpload(event, 'layout')}
-          style={{ display: 'grid', gap: '16px', border: '1px dashed rgba(59, 130, 246, 0.4)' }}>
-          <div>
-            <h3 style={{ margin: '0 0 4px' }}>Макет</h3>
-            <p style={{ margin: 0, color: 'rgba(15,23,42,0.6)', fontSize: '0.9rem' }}>
-              Прикрепите изображение макета (JPEG, PNG, WEBP), можно пропустить на этапе тестирования.
-            </p>
-          </div>
-          <input name="file" type="file" accept="image/jpeg,image/png,image/webp" />
-          <button className="button secondary" type="submit">
-            {layoutImageUrl ? 'Заменить макет' : 'Загрузить макет'}
-          </button>
-          {layoutImageUrl && (
-            <a href={layoutImageUrl} target="_blank" rel="noreferrer" className="badge">
-              Просмотреть изображение
-            </a>
-          )}
-        </form>
-      </div>
-      <form className="grid" onSubmit={handleSubmit} style={{ gap: '20px' }}>
+    <div className="grid" style={{ gap: '20px' }}>
+      <form
+        className="card"
+        onSubmit={handleSubmit}
+        style={{ display: 'grid', gap: '16px', border: '1px dashed rgba(59, 130, 246, 0.4)' }}
+      >
         <div>
-          <label htmlFor="projectTitle">Название или краткий тег</label>
-          <input
-            id="projectTitle"
-            value={projectTitle}
-            onChange={(event) => setProjectTitle(event.target.value)}
-            placeholder="Например, Лендинг Zero Defect Design"
-          />
+          <h3 style={{ margin: '0 0 4px' }}>Макет</h3>
+          <p style={{ margin: 0, color: 'rgba(15,23,42,0.6)', fontSize: '0.9rem' }}>
+            Прикрепите изображение макета (JPEG, PNG, WEBP). После загрузки мы автоматически запустим проверку.
+          </p>
         </div>
-        <div>
-          <label htmlFor="projectBrief">Техническое задание (бизнес-задача)</label>
-          <textarea
-            id="projectBrief"
-            value={projectBrief}
-            onChange={(event) => setProjectBrief(event.target.value)}
-            placeholder="Опишите, что должно решать этот макет. Поле можно оставить пустым."
-          />
-        </div>
-        <div>
-          <label htmlFor="structureJson">JSON макета</label>
-          <textarea
-            id="structureJson"
-            value={structureJson}
-            onChange={(event) => setStructureJson(event.target.value)}
-            placeholder='{"screens": [...], "components": [...]} (можно без JSON)'
-          />
-        </div>
-        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
-          <span className={`badge ${designSystemUrl ? 'success' : 'neutral'}`}>
-            Дизайн-система {designSystemUrl ? 'готова' : 'не загружена'}
-          </span>
-          <span className={`badge ${layoutImageUrl ? 'success' : 'neutral'}`}>
-            Макет {layoutImageUrl ? 'загружен' : 'не загружен'}
-          </span>
-        </div>
-        <p style={{ margin: 0, color: 'rgba(15,23,42,0.65)', fontSize: '0.85rem' }}>
-          Все поля можно заполнить частично или оставить пустыми — это удобно для демонстрации.
-        </p>
+        <input name="file" type="file" accept="image/jpeg,image/png,image/webp" disabled={isSubmitting} />
         <button className="button" type="submit" disabled={isSubmitting}>
-          {isSubmitting ? 'Запускаем оценку...' : 'Запустить оценку'}
+          {isSubmitting ? 'Отправляем...' : 'Отправить на проверку'}
         </button>
       </form>
-      {needsGoalConfirmation && businessGoalSuggestion && (
-        <div className="card" style={{ background: 'rgba(59,130,246,0.08)' }}>
-          <h3 style={{ marginTop: 0 }}>Мы определили бизнес-задачу</h3>
-          <p style={{ marginBottom: '1rem' }}>{businessGoalSuggestion}</p>
-          <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-            <button type="button" className="button" onClick={() => handleConfirmGoal(true)} disabled={isSubmitting}>
-              Подтвердить
-            </button>
-            <button
-              type="button"
-              className="button secondary"
-              onClick={() => handleConfirmGoal(false)}
-              disabled={isSubmitting}
-            >
-              Продолжить с моим текстом
-            </button>
-          </div>
-        </div>
-      )}
       {toast && (
         <div className={`toast ${toast.tone === 'danger' ? 'danger' : ''}`}>
           {toast.message}

--- a/components/EvaluationForm.tsx
+++ b/components/EvaluationForm.tsx
@@ -58,7 +58,17 @@ export function EvaluationForm() {
       });
 
       if (!response.ok) {
-        throw new Error('Ошибка при отправке макета на оценку.');
+        let message = 'Ошибка при отправке макета на оценку.';
+        try {
+          const data = (await response.json()) as { message?: string };
+          if (data?.message) {
+            message = data.message;
+          }
+        } catch (parseError) {
+          console.error('Не удалось разобрать сообщение об ошибке отправки оценки', parseError);
+        }
+
+        throw new Error(message);
       }
 
       setToast({ message: 'Оценка запущена. Проверьте историю через минуту.', tone: 'success' });

--- a/lib/evaluation.ts
+++ b/lib/evaluation.ts
@@ -1,130 +1,90 @@
 import { callGemini } from './gemini';
 import type { EvaluationRequest, EvaluationResult, StepResult } from './types';
 
-const PROMPT_LAYOUT_OVERVIEW = '[[PROMPT_LAYOUT_OVERVIEW]]';
-const PROMPT_DESIGN_QUALITY = '[[PROMPT_DESIGN_QUALITY]]';
-const PROMPT_ACCESSIBILITY = '[[PROMPT_ACCESSIBILITY]]';
-const PROMPT_DESIGN_SYSTEM = '[[PROMPT_DESIGN_SYSTEM]]';
-const PROMPT_FINAL_REPORT = '[[PROMPT_FINAL_REPORT]]';
-const PROMPT_VALIDATE_JSON = '[[PROMPT_VALIDATE_JSON]]';
-const PROMPT_VALIDATE_BRIEF = '[[PROMPT_VALIDATE_BRIEF]]';
+const PROMPT_COMPREHENSIVE_REVIEW = String.raw`<CONTEXT>
+Наша цель — провести максимально детальный и конкретный анализ макета, как в самом первом варианте, но изложить его выводы в понятной и структурированной манере, которую мы наработали позже.
+</CONTEXT>
 
-export interface ValidationResult {
-  jsonMatchesImage: boolean;
-  businessGoal?: string;
-  needsBusinessGoalConfirmation: boolean;
-}
+<TASK>
+Твоя текущая задача — **Комплексная оценка дизайна (детальный разбор)**.
 
-export async function validateInputs(request: EvaluationRequest): Promise<ValidationResult> {
-  const hasLayoutReference = request.layoutImageUrl.trim().length > 0;
-  const hasStructure = request.structureJson.trim().length > 0;
+Проведи системный и исчерпывающий анализ макета по всем перечисленным ниже критериям. Твоя задача — не пропускать ни одного пункта, а дать по каждому из них конкретную оценку, подкрепленную данными из макета.
+</TASK>
 
-  if (!hasLayoutReference || !hasStructure) {
-    return {
-      jsonMatchesImage: true,
-      needsBusinessGoalConfirmation: false,
-    };
-  }
+<TONE_AND_STYLE_GUIDELINES>
+1.  **Человекочитаемые ссылки:** Это правило сохраняется. **Всегда** сначала описывай элемент словами (что это и где находится), и только потом в скобках можно указать ID для справки.
+    * **Пример:** "У кнопки 'Добавить в корзину' (E2.5) в блоке с ценой (B3)..."
 
-  const jsonCheck = await callGemini(PROMPT_VALIDATE_JSON, {
-    structureJson: request.structureJson,
-    layoutImageUrl: request.layoutImageUrl,
-  });
+2.  **Опора на данные:** Подкрепляй каждое наблюдение конкретными значениями из макета (например, \`размер шрифта: 15px\`, \`lineHeight: 22\`, \`цвет: #000000\`, \`отступ: 28px\`). Это возвращает анализу необходимую конкретику.
 
-  const matches = /\b(да|yes|true)\b/i.test(jsonCheck);
+3.  **Сухой и предметный тон:** Говори как опытный арт-директор — уважительно, но по делу и без "воды". **Сосредоточься на поиске ошибок и недочетов.** Твоя задача — найти проблемы, а не хвалить дизайнера. Объясняй, *почему* тот или иной аспект важен с точки зрения UX.
+</TONE_AND_STYLE_GUIDELINES>
 
-  if (!matches) {
-    return {
-      jsonMatchesImage: false,
-      needsBusinessGoalConfirmation: false,
-    };
-  }
+<INSTRUCTIONS>
+Системно проанализируй макет по **ВСЕМ** подпунктам в категориях ниже, выявляя проблемы и потенциальные улучшения. Не выбирай 1-2 примера, а методично проходи по всему списку. Если с каким-то пунктом проблем не найдено, не включай его в отчет.
 
-  const briefText = request.projectBrief.trim();
-  if (!briefText) {
-    return {
-      jsonMatchesImage: true,
-      needsBusinessGoalConfirmation: false,
-    };
-  }
+**Категории и критерии для обязательного анализа:** **0. Соответствие дизайн-задаче**
+   * Проанализируй, насколько текущий дизайн эффективно решает задачу, определенную на Шаге 1.
+   * Выяви элементы или композиционные решения, которые могут мешать пользователю в достижении цели (например, отвлекающие визуальные элементы, нелогичное расположение CTA, недостаток ключевой информации).
 
-  const briefCheck = await callGemini(PROMPT_VALIDATE_BRIEF, {
-    projectBrief: request.projectBrief,
-    structureJson: request.structureJson,
-  });
+**1.  Типографика:**
+   * Читаемость основного текста (размер, интервалы).
+   * Контраст текста и фона (оценка по WCAG).
+   * Иерархия текстовых стилей (как заголовки отличаются от подзаголовков и текста, используя названия стилей из карты макета).
+   * Межстрочные и межбуквенные интервалы.
 
-  const goalMatch = briefCheck.match(/goal:(.*)/i);
-  const goalText = (goalMatch ? goalMatch[1].trim() : briefCheck.trim()) || request.projectBrief;
-  const confident = /\b(уверен|понятно|clear|definite)\b/i.test(briefCheck);
+**2.  Композиция и принцип близости:**
+   * Группировка связанных по смыслу элементов.
+   * Использование отступов для создания визуальных групп и "воздуха".
+   * Баланс между плотностью информации и пустым пространством.
 
-  return {
-    jsonMatchesImage: true,
-    businessGoal: goalText,
-    needsBusinessGoalConfirmation: !confident,
-  };
-}
+**3.  Визуальная иерархия:**
+   * Общая визуальная иерархия всего макета (что пользователь видит в первую, вторую, третью очередь).
+   * Приоритизация информации внутри каждого отдельного блока.
+   * Использование визуальных акцентов (цвет, размер, жирность) для выделения важного.
+
+**4.  Эстетика и консистентность:**
+   * Общее визуальное впечатление и согласованность стилей.
+   * Цветовая гармония и использование палитры.
+
+**Для каждого проанализированного подпункта используй следующий формат:** </INSTRUCTIONS>
+
+<OUTPUT_FORMAT>
+---
+**0. Соответствие дизайн-задаче**
+
+* **Наблюдение:** (Детальный анализ того, как макет решает (или не решает) поставленную задачу. Например: "Основная задача — быстрая покупка товара. Однако, кнопка 'Добавить в корзину' (E2.5) имеет недостаточный визуальный вес по сравнению с блоком 'Рекомендованные товары' (B4), что может отвлекать пользователя от целевого действия.")
+* **Рекомендация:** (Что нужно сделать для лучшего решения задачи. Например: "Рекомендую усилить акцент на кнопке (E2.5), возможно, используя более контрастный цвет из палитры Primary, и уменьшить визуальный вес блока B4.")
+* **Критичность:** (Высокая)
+
+---
+**1. Типографика** **1.2. Контраст текста и фона**
+* **Наблюдение:** (Анализ контраста. Например: "Второстепенный текст в блоке адреса (E4.3) имеет серый цвет (r:0.458), что на светло-сером фоне может не соответствовать минимальному уровню контраста WCAG AA. Это ухудшает доступность...")
+* **Рекомендация:** (Например: "Рекомендую проверить данный цвет через контраст-чекер и, при необходимости, сделать его темнее, используя токен \`content/secondary\` из дизайн-системы.")
+* **Критичность:** (Низкая)
+
+*(... и так далее по всем пунктам и подпунктам, где найдены проблемы)* </OUTPUT_FORMAT>`;
 
 export async function runEvaluation(request: EvaluationRequest) {
-  const steps: StepResult[] = [];
-
-  const hasVisualContext = request.layoutImageUrl.trim().length > 0 || request.structureJson.trim().length > 0;
-
-  if (hasVisualContext) {
-    const layoutOverview = await callGemini(PROMPT_LAYOUT_OVERVIEW, request);
-    steps.push({ step: 'layoutOverview', content: layoutOverview });
-
-    const designQuality = await callGemini(PROMPT_DESIGN_QUALITY, request);
-    steps.push({ step: 'designQuality', content: designQuality });
-
-    const accessibility = await callGemini(PROMPT_ACCESSIBILITY, request);
-    steps.push({ step: 'accessibility', content: accessibility });
-  } else {
-    const placeholder =
-      'Недостаточно данных макета (JSON или изображение не загружены), поэтому автоматическая оценка пропущена.';
-    steps.push({ step: 'layoutOverview', content: placeholder });
-    steps.push({ step: 'designQuality', content: placeholder });
-    steps.push({ step: 'accessibility', content: placeholder });
-  }
-
-  if (request.designSystemUrl.trim().length > 0) {
-    const designSystem = await callGemini(PROMPT_DESIGN_SYSTEM, request);
-    steps.push({ step: 'designSystem', content: designSystem });
-  } else {
-    steps.push({
-      step: 'designSystem',
-      content: 'Дизайн-система не предоставлена, оценка этого пункта пропущена.',
-    });
-  }
-
-  const finalReport = await callGemini(PROMPT_FINAL_REPORT, {
-    ...request,
-    steps,
+  const analysis = await callGemini(PROMPT_COMPREHENSIVE_REVIEW, {
+    layoutImageUrl: request.layoutImageUrl,
+    projectTitle: request.projectTitle,
   });
-  steps.push({ step: 'finalReport', content: finalReport });
 
+  const steps: StepResult[] = [{ step: 'finalReport', content: analysis }];
   return steps;
 }
 
 export function buildSummary(steps: StepResult[], request: EvaluationRequest): EvaluationResult['summary'] {
   const createdAt = new Date().toISOString();
   const normalizedTitle = request.projectTitle.trim();
+
   return {
     id: `${Date.now()}`,
     title: normalizedTitle || 'Оценка макета',
     status: 'complete',
-    projectSummary: request.projectBrief.trim().slice(0, 160),
+    projectSummary: 'Детальный отчёт по загруженному макету.',
     createdAt,
-    scores: [
-      { label: 'Обзор', value: extractScore(steps, 'layoutOverview') },
-      { label: 'Качество', value: extractScore(steps, 'designQuality') },
-      { label: 'Доступность', value: extractScore(steps, 'accessibility') },
-      { label: 'Дизайн-система', value: extractScore(steps, 'designSystem') },
-    ],
+    scores: [],
   };
-}
-
-function extractScore(steps: StepResult[], key: StepResult['step']) {
-  const text = steps.find((step) => step.step === key)?.content ?? '';
-  const match = text.match(/score\s*[:=]\s*(\d{1,2}\/?10)/i);
-  return match ? match[1] : 'n/a';
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,9 +21,6 @@ export interface EvaluationSummary {
 
 export interface EvaluationRequest {
   projectTitle: string;
-  projectBrief: string;
-  structureJson: string;
-  designSystemUrl: string;
   layoutImageUrl: string;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2020"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -14,8 +18,24 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["next", "next/types/global"]
+    "types": [
+      "next",
+      "next/types/global"
+    ],
+    "noEmit": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- collapse the dashboard evaluation form into a single image upload that immediately triggers a review request
- streamline the evaluations API and types for image-only payloads and use the new comprehensive analysis prompt
- update TypeScript config via next lint to include Next.js defaults

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e615f38b9083318436346fc29d0b79